### PR TITLE
fix: autocomplete issue fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=3.0.5
+version=3.0.6
 
 org.gradle.daemon=true
 org.gradle.parallel=true

--- a/testit-java-commons/src/main/java/ru/testit/services/core/AdapterTestCaseHelper.java
+++ b/testit-java-commons/src/main/java/ru/testit/services/core/AdapterTestCaseHelper.java
@@ -151,7 +151,18 @@ public class AdapterTestCaseHelper {
             logger.debug("Stop test case {}", testResult);
         }
 
-        if (syncStorageService.sendInProgressIfNeeded(testResult)) {
+        boolean inProgressSent = false;
+        try {
+            inProgressSent = syncStorageService.sendInProgressIfNeeded(testResult);
+        } catch (Exception e) {
+            logger.warn(
+                    "Failed to send in-progress result to SyncStorage, fallback to final Test IT result: {}",
+                    e.getMessage()
+            );
+        }
+
+        // отправлять в Test IT inProgress только при успешной записи в sync-storage
+        if (inProgressSent) {
             markTestAsInProgress(testResult);
             writer.writeTestRealtime(testResult);
             return;

--- a/testit-java-commons/src/main/java/ru/testit/syncstorage/ClientWrapper.java
+++ b/testit-java-commons/src/main/java/ru/testit/syncstorage/ClientWrapper.java
@@ -22,17 +22,17 @@ public class ClientWrapper {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClientWrapper.class);
     private static final int API_CONNECT_TIMEOUT_MS = 10000;
     private static final int API_READ_TIMEOUT_MS = 10000;
+    private static final int RETRY_MAX_ATTEMPTS = 5;
+    private static final long RETRY_DELAY_MS = 1000L;
 
     public RegistrationResult registerWorker(String url, String testRunId) {
-        try {
+        return executeWithRetry("register worker", () -> {
             String workerPid =
                     "worker-" +
                             Thread.currentThread().getId() +
                             "-" +
                             System.currentTimeMillis();
-
             LOGGER.info("register on {}/register", url);
-
             WorkersApi workersApi = new WorkersApi(buildApiClient(url));
             RegisterResponse response = workersApi.registerPost(
                     new RegisterRequest()
@@ -40,12 +40,8 @@ public class ClientWrapper {
                             .testRunId(testRunId)
             );
             boolean isMaster = Boolean.TRUE.equals(response.getIsMaster());
-
             return new RegistrationResult(workerPid, isMaster);
-        } catch (Exception e) {
-            LOGGER.error("Error on worker registering: {}", e.getMessage());
-            return null;
-        }
+        }, null);
     }
 
     public boolean setWorkerStatus(
@@ -54,7 +50,7 @@ public class ClientWrapper {
             String status,
             String testRunId
     ) {
-        try {
+        Boolean result = executeWithRetry("set worker status", () -> {
             WorkersApi workersApi = new WorkersApi(buildApiClient(url));
             workersApi.setWorkerStatusPost(
                     new SetWorkerStatusRequest()
@@ -62,11 +58,9 @@ public class ClientWrapper {
                             .status(status)
                             .testRunId(testRunId)
             );
-            return true;
-        } catch (Exception e) {
-            LOGGER.warn("Failed to set worker status: {}", e.getMessage());
-            return false;
-        }
+            return Boolean.TRUE;
+        }, Boolean.FALSE);
+        return Boolean.TRUE.equals(result);
     }
 
     public boolean sendTestResultToSyncStorage(
@@ -75,17 +69,58 @@ public class ClientWrapper {
             TestResult testResult,
             String projectId
     ) {
-        try {
+        Boolean result = executeWithRetry("send test result to SyncStorage", () -> {
             TestResultsApi testResultsApi = new TestResultsApi(buildApiClient(url));
             testResultsApi.inProgressTestResultPost(
                     testRunId,
                     toTestResultCutApiModel(testResult, projectId)
             );
-            return true;
-        } catch (Exception e) {
-            LOGGER.warn("Failed to send test result to SyncStorage: {}", e.getMessage());
-            return false;
+            return Boolean.TRUE;
+        }, Boolean.FALSE);
+        return Boolean.TRUE.equals(result);
+    }
+
+    private <T> T executeWithRetry(String operationName, RetryOperation<T> operation, T fallbackValue) {
+        Exception lastException = null;
+        for (int attempt = 1; attempt <= RETRY_MAX_ATTEMPTS; attempt++) {
+            try {
+                return operation.execute();
+            } catch (Exception e) {
+                lastException = e;
+                LOGGER.warn(
+                        "Failed to {} (attempt {}/{}): {}",
+                        operationName,
+                        attempt,
+                        RETRY_MAX_ATTEMPTS,
+                        e.getMessage()
+                );
+                if (attempt == RETRY_MAX_ATTEMPTS) {
+                    break;
+                }
+                try {
+                    Thread.sleep(RETRY_DELAY_MS);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException(
+                            "Interrupted while retrying SyncStorage request",
+                            ie
+                    );
+                }
+            }
         }
+
+        LOGGER.error(
+                "Failed to {} after {} attempts",
+                operationName,
+                RETRY_MAX_ATTEMPTS,
+                lastException
+        );
+        return fallbackValue;
+    }
+
+    @FunctionalInterface
+    private interface RetryOperation<T> {
+        T execute() throws Exception;
     }
 
     private ApiClient buildApiClient(String url) {

--- a/testit-java-commons/src/main/java/ru/testit/syncstorage/SyncStorageRunner.java
+++ b/testit-java-commons/src/main/java/ru/testit/syncstorage/SyncStorageRunner.java
@@ -44,7 +44,7 @@ public class SyncStorageRunner {
     private boolean isExternal = false;
 
 
-    private static final String SYNC_STORAGE_VERSION = "v0.3.0";
+    private static final String SYNC_STORAGE_VERSION = "v0.3.1";
 
     private static final String SYNC_STORAGE_REPO_URL ="https://github.com/testit-tms/sync-storage-public/releases/download/";
     private static final String AMD64 = "amd64";

--- a/testit-java-commons/src/main/java/ru/testit/syncstorage/SyncStorageService.java
+++ b/testit-java-commons/src/main/java/ru/testit/syncstorage/SyncStorageService.java
@@ -69,7 +69,12 @@ public class SyncStorageService {
                     "Successfully sent test result to SyncStorage for test: {}",
                     testResult.getExternalId()
             );
+            return;
         }
+
+        throw new IllegalStateException(
+                "Failed to send test result to SyncStorage after retry attempts"
+        );
     }
 
     public void setWorkerStatus(String status) {


### PR DESCRIPTION
при завершении процесса sync-storage по таймауту (в случае очень медленных тестов или ошибок обновления) последующие воркеры не фоллбекались на финальный статус, а отправляли в Test IT незавершенный статус InProgress, который некому было завершить